### PR TITLE
Fixes request to graphite when target contains weird characters

### DIFF
--- a/jquery.tswidget.js
+++ b/jquery.tswidget.js
@@ -44,9 +44,9 @@ function build_graphite_options(options, raw) {
                         // so we need a good string identifier and set it using alias() (which graphite will honor)
                         // so that we recognize the returned output. simplest is just to include the target spec again
                         // though this duplicates a lot of info in the url.
-                        clean_options.push("target=alias(" + encodeURIComponent(value.target) + ",'" + value.target +"')");
+                        clean_options.push("target=alias(" + encodeURIComponent(value.target) + ",'" + encodeURIComponent(value.target) +"')");
                     } else {
-                        clean_options.push("target=alias(color(" +encodeURIComponent(value.target + ",'" + value.color) +"'),'" + value.name +"')");
+                        clean_options.push("target=alias(color(" +encodeURIComponent(value.target + ",'" + value.color) +"'),'" + encodeURIComponent(value.name) +"')");
                     }
             });
         } else if (value !== null) {


### PR DESCRIPTION
We must ensure we encore correctly EVERY single parameter we pass to graphite through http
(if target.name is "CPU+" for example)
